### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Your choice of server software can make a huge difference in performance and api
 Recommended top picks:
 * [Paper](https://github.com/PaperMC/Paper) - The most popular server software that aims to improve performance while fixing gameplay and mechanics inconsistencies.
 * [Tuinity](https://github.com/Spottedleaf/Tuinity) - Paper fork that includes even more high-performance patches.
-* [Purpur](https://github.com/pl3xgaming/Purpur) - Tuinity fork focused on features, the freedom of customization, and even more high-performance patches.
+* [Purpur](https://github.com/pl3xgaming/Purpur) - Tuinity fork focused on features, the freedom of customization, and aims to further improve server performance.
 
 You should stay away from:
 * Yatopia - "The combined power of Paper forks for maximum instability and unmaintainablity!" - [KennyTV's list of shame](https://github.com/KennyTV/list-of-shame). Nothing more to be said.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Your choice of server software can make a huge difference in performance and api
 Recommended top picks:
 * [Paper](https://github.com/PaperMC/Paper) - The most popular server software that aims to improve performance while fixing gameplay and mechanics inconsistencies.
 * [Tuinity](https://github.com/Spottedleaf/Tuinity) - Paper fork that includes even more high-performance patches.
-* [Purpur](https://github.com/pl3xgaming/Purpur) - Tuinity fork focused on features, the freedom of customization, even more high-performance patches.
+* [Purpur](https://github.com/pl3xgaming/Purpur) - Tuinity fork focused on features, the freedom of customization, and even more high-performance patches.
 
 You should stay away from:
 * Yatopia - "The combined power of Paper forks for maximum instability and unmaintainablity!" - [KennyTV's list of shame](https://github.com/KennyTV/list-of-shame). Nothing more to be said.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Your choice of server software can make a huge difference in performance and api
 Recommended top picks:
 * [Paper](https://github.com/PaperMC/Paper) - The most popular server software that aims to improve performance while fixing gameplay and mechanics inconsistencies.
 * [Tuinity](https://github.com/Spottedleaf/Tuinity) - Paper fork that includes even more high-performance patches.
-* [Purpur](https://github.com/pl3xgaming/Purpur) - Tuinity fork focused on features and the freedom of customization.
-* [Airplane](https://github.com/Technove/Airplane) - Tuinity fork that aims to further improve server performance.
+* [Purpur](https://github.com/pl3xgaming/Purpur) - Tuinity fork focused on features, the freedom of customization, even more high-performance patches.
 
 You should stay away from:
 * Yatopia - "The combined power of Paper forks for maximum instability and unmaintainablity!" - [KennyTV's list of shame](https://github.com/KennyTV/list-of-shame). Nothing more to be said.


### PR DESCRIPTION
Purpur dropped Airplane's patches for a reason:

"After much internal deliberation we have come to the conclusion that it is in the best interest of Purpur and it's users that we drop Airplane's set of patches from our software.

Airplane doesn't give us nearly as much performance as we originally thought it would as it's just a small set of micro optimizations, most of which don't really give any noticeable gains at all outside of extreme circumstances. The few features that do actually change the game have done so in unexpected and unwanted ways for the majority of our users, the most notable one being DEAR.

Between these technical concerns, the voices of our users that have had problems or confirmed airplane hasn't helped them at all, and the negativity we continue to receive from the Airplane community and team in general, the decision to remove the patches was a rather simple one to make.

Fear not! Purpur is still based on Tuinity where majority of the performance gains over Paper come from. And don't forget Purpur still has its own performance oriented patches on top of that for that extra zing!

We look forward with anticipation to what the future brings us as we approach 1.17 and hope to continue giving you the best possible performance and experience running your Minecraft servers ^_^"