### PR TITLE
Add section for CPU Scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,12 @@ If this option is greater that `0`, players above the set y level will be damage
 
 Your garbage collector can be configured to reduce lag spikes caused by big garbage collector tasks. You can find startup flags optimized for minecraft servers [here](https://mcflags.emc.gs/) [`SOG`]. Keep in mind that this recommendation will not work on alternative jvm implementations.
 
+# Linux cpu scaling 
+Hosts such as OVH and Hetzner are known to ship machines running in "PowerSave" mode. This can result in around 25% lower clock speeds and thus vastly lower single threaded performance, leading to less TPS than the cpu is capable of.
+
+On Debian / Ubuntu running `Cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor` will show the cpus performance profile.
+Then running `echo "performance" | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor` will set to performance.
+
 # "Too good to be true" plugins
 
 ## Plugins removing ground items

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ If this option is greater that `0`, players above the set y level will be damage
 Your garbage collector can be configured to reduce lag spikes caused by big garbage collector tasks. You can find startup flags optimized for minecraft servers [here](https://mcflags.emc.gs/) [`SOG`]. Keep in mind that this recommendation will not work on alternative jvm implementations.
 
 # Linux cpu scaling 
-Hosts such as OVH and Hetzner are known to ship machines running in "PowerSave" mode. This can result in around 25% lower clock speeds and thus vastly lower single threaded performance, leading to less TPS than the cpu is capable of.
+Some hosts might ship machines running in "PowerSave" mode. This can result in nearly 25% lower clock speeds and thus vastly lower single threaded performance. This can lead to severly worse performance than setting the cpu scaling to performance mode.
 
 On Debian / Ubuntu running `Cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor` will show the cpus performance profile.
 Then running `echo "performance" | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor` will set to performance.


### PR DESCRIPTION
I asked a few people to show what profile their cpu was set to. All 4 of them showed theirs to be in powersave (With hosts from both Hetzner & OVH) and upon switching profile saw a SIGNIFICANT increase in clock speed and decrease in mspt. No other guide mentions this fact and i believe it has a major impact with no downsides.

(This is my first ever time creating a fork or PR request, so apologies if I did something incorrectly)