### PR TITLE
replace radius in worldborder cmd with diameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you still want to pregen the world, you can use a plugin such as [Chunky](htt
 
 It's key to remember that the overworld, nether and the end have separate world borders that need to be set up for each world. The nether dimension is 8x smaller than the overworld (if not modified with a datapack), so if you set the size wrong your players might end up outside of the world border!
 
-**Make sure to set up a vanilla world border (`/worldborder set [radius]`), as it limits certain functionalities such as lookup range for treasure maps that can cause lag spikes.**
+**Make sure to set up a vanilla world border (`/worldborder set [diameter]`), as it limits certain functionalities such as lookup range for treasure maps that can cause lag spikes.**
 
 # Configurations
 


### PR DESCRIPTION
The vanilla worldborder uses diameter for both getting and setting.