### PR TITLE
(1.20) Update Minecraft Wiki links to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ To get Timings of your server, you just need to execute the `/timings paste` com
 To see how to fix exploits that can cause lag spikes or crashes on a Minecraft server, refer to [here](https://github.com/YouHaveTrouble/minecraft-exploits-and-how-to-fix-them).
 
 [`SOG`]: https://www.spigotmc.org/threads/guide-server-optimization%E2%9A%A1.283181/
-[server.properties]: https://minecraft.fandom.com/wiki/Server.properties
+[server.properties]: https://minecraft.wiki/w/Server.properties
 [bukkit.yml]: https://bukkit.fandom.com/wiki/Bukkit.yml
 [spigot.yml]: https://www.spigotmc.org/wiki/spigot-configuration/
 [paper-global configuration]: https://docs.papermc.io/paper/reference/global-configuration


### PR DESCRIPTION


The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the previous fandom wiki link accordingly.
