### PR TITLE
Add wet-farmland

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ Time in ticks between container updates. Increasing this might help if container
 
 #### tick-rates.wet-farmland
 
-`Good starting value: 4`
+`Good starting value: 2`
 
 Time in ticks between the server trying to dry wet-farmland. Wet farmland slowly drying out does not significantly impact gameplay. Increasing this value can help reduce lag caused by farmland.
 

--- a/README.md
+++ b/README.md
@@ -511,6 +511,12 @@ Time in ticks between the server trying to spread grass or mycelium. This will m
 
 Time in ticks between container updates. Increasing this might help if container updates cause issues for you (it rarely happens), but makes it easier for players to experience desync when interacting with inventories (ghost items).
 
+#### tick-rates.wet-farmland
+
+`Good starting value: 4`
+
+Time in ticks between the server trying to dry wet-farmland. Wet farmland slowly drying out does not significantly impact gameplay. Increasing this value can help reduce lag caused by farmland.
+
 #### non-player-arrow-despawn-rate
 
 `Good starting value: 20`


### PR DESCRIPTION
https://github.com/PaperMC/Paper/pull/9968

> There are two options: dry-farmland and wet-farmland, the reason it is separate is because the performance impact of dry farmlands isn't that big, but has a big gameplay impact where players may be confused about why the farmland isn't wet after placing water near it. Yes, dry farmlands have the same isNearWater checks as wet farmlands, but dry farmlands do end up turning to regular dirt after a while, so it is like they are "naturally" throttled by the server.