### PR TITLE
Remove recommendation of the Aikars flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,8 +579,7 @@ If this option is greater that `0`, players above the set y level will be damage
 # Java startup flags
 [Vanilla Minecraft and Minecraft server software in version 1.19 requires Java 17 or higher](https://docs.papermc.io/java-install-update). Oracle has changed their licensing, and there is no longer a compelling reason to get your java from them. Recommended vendors are [Adoptium](https://adoptium.net/) and [Amazon Corretto](https://aws.amazon.com/corretto/). Alternative JVM implementations such as OpenJ9 or GraalVM can work, however they are not supported by Paper and have been known to cause issues, therefore they are not currently recommended.
 
-Your garbage collector can be configured to reduce lag spikes caused by big garbage collector tasks. You can find startup flags optimized for Minecraft servers [here](https://docs.papermc.io/paper/aikars-flags) [`SOG`]. Keep in mind that this recommendation will not work on alternative JVM implementations.
-It's recommended to use the [flags.sh](https://flags.sh) startup flags generator to get the correct startup flags for your server
+On Java 17, it is recommended you set `-XX:+UseShenandoahGC` for garbage collection, and on Java 21 it is recommended you set `-XX:+UseZGC -XX:+ZGenerational`. The commonly-shared Aikars flags are [not recommended](https://noflags.sh/about/) for modern Java versions and will have a significant impact on your performance.
 
 In addition, adding the beta flag `--add-modules=jdk.incubator.vector` before `-jar` in your startup flags can improve performance. This flag enables Pufferfish to use SIMD instructions on your CPU, making some maths faster. Currently, it's only used for making rendering in game plugin maps (like imageonmaps) possibly 8 times faster.
 


### PR DESCRIPTION
The Aikars flags are old and outdated. Using them on Java 17 and 21 does users a *massive* disservice, as they are built around the archaic G1 garbage collector. Shenandoah on Java 17 and Generational ZGC on Java 21 are *significantly* more performant, with GenZGC providing [*sub-millisecond* maximum GC pauses](https://malloc.se/blog/zgc-jdk16).