### PR TITLE
Revise mob stacker plugins section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ It's recommended to use the [flags.sh](https://flags.sh) startup flags generator
 Absolutely unnecessary since they can be replaced with [merge-radius](#merge-radius) and [alt-item-despawn-rate](#alt-item-despawn-rate) and frankly, they're less configurable than basic server configs. They tend to use more resources scanning and removing items than not removing the items at all.
 
 ## Mob stacker plugins
-It's really hard to justify using one. Stacking naturally spawned entities causes more lag than not stacking them at all due to the server constantly trying to spawn more mobs. The only "acceptable" use case is for spawners on servers with a large amount of spawners.
+Using a mob stacker plugin is significant for servers having high usage from ticking entities, specially if you have a lot of farms or mob spawners. If your server has a lot of those, using a mob stacker is essential to prevent crowding of entities. Don't rely on players cleaning up their farms, as staying afk for long can overcrowd your server in one night and significantly reduce TPS. A good updated free mob stacker from a well known developer is [MobStacker by iChoco](https://www.spigotmc.org/resources/mobstacker.106631/) a more advanced alternative can be [MobStacker by LinsaFTW](https://builtbybit.com/resources/mobstacker-optimize-server-performance.23141/).
 
 ## Plugins enabling/disabling other plugins
 Anything that enables or disables plugins on runtime is extremely dangerous. Loading a plugin like that can cause fatal errors with tracking data and disabling a plugin can lead to errors due to removing dependency. The `/reload` command suffers from exact same issues and you can read more about them in [me4502's blog post](https://madelinemiller.dev/blog/problem-with-reload/)


### PR DESCRIPTION
Updated the section on mob stacker plugins to emphasize their importance for servers with high entity usage and provided recommendations for specific plugins.

The guide was outdated / not well documented in saying that mob stackers are not necessary, in reality, they really are. When players stay in farms AFK for too long, these can overcrowd the server and overload it with entities, or even crash clients because of rendering of entities.

Also can prevent player specifically abusing spawning entities to crash or lag the server acknowledgely.

Stacking entities asynchronously adds little CPU usage for the great benefit of not losing gameplay (you still spawn mobs) while just ticking only one entity.

All big serious server use mob stacking. This aligns the guide with real usage and real experience.

Also I personally work with a lot of servers, one of the biggest problems is farms overcrowding and ticking of entities being a massive hog when there are more than 10.000 entities in one chunk. And server owners dont want to lose functionality of their farms.

I proposed two plugins, one made by my friend iChoco, which is well known in the spanish community, and the other by me.